### PR TITLE
feat: add supported D1 column types

### DIFF
--- a/cmd/sqlc-gen-ts-d1/main.go
+++ b/cmd/sqlc-gen-ts-d1/main.go
@@ -393,11 +393,15 @@ func (t *TsTypeMap) toTsType(col *plugin.Column) string {
 }
 
 func buildTsTypeMap(settings *plugin.Settings) *TsTypeMap {
+	// https://developers.cloudflare.com/d1/platform/client-api/#type-conversion
 	m := map[string]string{
+		"NULL":     "null",
+		"REAL":     "number",
 		"INTEGER":  "number",
 		"TEXT":     "string",
 		"DATETIME": "string",
 		"JSON":     "string",
+		"BLOB":     "ArrayBuffer",
 	}
 	for _, o := range settings.GetOverrides() {
 		m[strings.ToUpper(o.GetDbType())] = o.GetCodeType()


### PR DESCRIPTION
D1でサポートされている型として[ドキュメント](https://developers.cloudflare.com/d1/platform/client-api/#type-conversion)に明記されている以下の型を扱えるようにしました。

- `NULL`
- `REAL`
- `BLOB`